### PR TITLE
Normalizing case on GitLabHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.swp
 *~
 node_modules

--- a/handler.js
+++ b/handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var GitlabHandler = require('./lib/GitlabHandler');
+var GitLabHandler = require('./lib/GitLabHandler');
 
 var exports = function() {
   this.configure = this.configure.bind(this);
@@ -34,7 +34,7 @@ exports.options = function(yargs) {
 };
 
 exports.configure = function(config) {
-  server = new GitlabHandler(config);
+  server = new GitLabHandler(config);
 };
 
 exports.run = function(cb) {


### PR DESCRIPTION
On case-sensitive systems, handler.js would fail trying to find GitLabHandler.js when referred to as GitlabHandler.js. I have compensated for that in this file.